### PR TITLE
Store data on invalid eTLD but do not send an observation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -168,15 +168,6 @@ func (a *appHandle) handleMsg(ctx context.Context, msg common.NatsMsg) {
 		}
 	}
 
-	if a.includeInvalidETLDs {
-		/* Just continue */
-	} else {
-		if !libtapir.HasValidETLD(msgDomain) {
-			a.log.Debug("%s has invalid eTLD, will not generate observation", msgDomain)
-			return
-		}
-	}
-
 	thumbprint, ok := msg.Headers[common.NATSHEADER_KEY_THUMBPRINT]
 	if !ok {
 		a.log.Error("Missing thumbprint for NEW_QNAME event, discarding...")
@@ -195,6 +186,15 @@ func (a *appHandle) handleMsg(ctx context.Context, msg common.NatsMsg) {
 		return
 	} else {
 		a.log.Info("Got event for unseen domain '%s'", msgDomain)
+
+		if a.includeInvalidETLDs {
+			/* Just continue */
+		} else {
+			if !libtapir.HasValidETLD(msgDomain) {
+				a.log.Debug("%s has invalid eTLD, will not generate observation. Done handling event.", msgDomain)
+				return
+			}
+		}
 
 		err = a.natsHandle.SetObservation(ctx, msgDomain, common.OBS_GLOBALLY_NEW)
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of newly seen domains so invalid entries are filtered at the right stage.
  * Prevents certain domain events from being processed further once they’re identified as invalid, reducing unnecessary downstream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->